### PR TITLE
feat: Initial build of Nias Variation Swatches plugin

### DIFF
--- a/nias-variation-swatches/assets/css/frontend.css
+++ b/nias-variation-swatches/assets/css/frontend.css
@@ -1,0 +1,47 @@
+.ns-vr-swatches-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.ns-vr-swatch {
+    cursor: pointer;
+    border: 2px solid #e0e0e0;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    transition: all 0.3s ease;
+}
+
+.ns-vr-swatch:hover {
+    border-color: #999;
+}
+
+.ns-vr-swatch.selected {
+    border-color: #000;
+    box-shadow: 0 0 3px rgba(0,0,0,0.4);
+}
+
+.ns-vr-swatch-color {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.ns-vr-swatch-label {
+    padding: 0 10px;
+    font-size: 14px;
+    text-align: center;
+    color: #333;
+    background-color: #f7f7f7;
+    border: 1px solid #ddd;
+}
+
+.ns-vr-swatch.selected .ns-vr-swatch-label {
+    background-color: #333;
+    color: #fff;
+    border-color: #000;
+}

--- a/nias-variation-swatches/assets/js/frontend.js
+++ b/nias-variation-swatches/assets/js/frontend.js
@@ -1,0 +1,47 @@
+jQuery(document).ready(function($) {
+    function trigger_variation_change() {
+        $('form.variations_form').trigger('woocommerce_variation_select_change');
+        $('form.variations_form').trigger('check_variations');
+    }
+
+    $('.ns-vr-swatches-container').on('click', '.ns-vr-swatch', function(e) {
+        e.preventDefault();
+
+        var $swatch = $(this);
+        var $container = $swatch.closest('.ns-vr-swatches-container');
+        var $select = $container.next('.original-variation-select').find('select');
+        var value = $swatch.data('value');
+
+        if ($swatch.hasClass('selected')) {
+            // If the swatch is already selected, deselect it.
+            $swatch.removeClass('selected');
+            $select.val('').trigger('change');
+        } else {
+            // Deselect other swatches in the same container.
+            $container.find('.ns-vr-swatch').removeClass('selected');
+            // Select the clicked swatch.
+            $swatch.addClass('selected');
+            // Update the hidden select dropdown.
+            $select.val(value).trigger('change');
+        }
+
+        trigger_variation_change();
+    });
+
+    // When the "Clear" button is clicked
+    $('.variations_form').on('click', '.reset_variations', function() {
+        $('.ns-vr-swatch.selected').removeClass('selected');
+    });
+
+    // When a variation is found, make sure the right swatches are selected
+    $(document).on('found_variation', 'form.variations_form', function( event, variation ) {
+        $.each(variation.attributes, function(attribute, value){
+            var $swatch = $('.ns-vr-swatch[data-value="' + value + '"]');
+            if ($swatch.length) {
+                var $container = $swatch.closest('.ns-vr-swatches-container');
+                $container.find('.ns-vr-swatch').removeClass('selected');
+                $swatch.addClass('selected');
+            }
+        });
+    });
+});

--- a/nias-variation-swatches/includes/class-admin-menu.php
+++ b/nias-variation-swatches/includes/class-admin-menu.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Admin Menu and Settings Page Management
+ *
+ * @package Nias_Variation_Swatches
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class NS_VR_Admin_Menu {
+    public function __construct() {
+        add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+    }
+
+    public function admin_menu() {
+        add_menu_page(
+            __( 'تنظیمات متغیر پیشرفته نیاس', 'nias-variation-swatches' ),
+            __( 'متغیر پیشرفته نیاس', 'nias-variation-swatches' ),
+            'manage_options',
+            'nias-variation-swatches-settings',
+            array( $this, 'settings_page' ),
+            'dashicons-admin-settings',
+            58
+        );
+    }
+
+    public function settings_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields( 'ns_vr_settings_group' );
+                do_settings_sections( 'nias-variation-swatches-settings' );
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    public function register_settings() {
+        register_setting( 'ns_vr_settings_group', 'ns_vr_settings', array( 'sanitize_callback' => array( $this, 'sanitize_settings' ) ) );
+
+        // General Section
+        add_settings_section(
+            'ns_vr_general_section',
+            __( 'تنظیمات عمومی', 'nias-variation-swatches' ),
+            null,
+            'nias-variation-swatches-settings'
+        );
+
+        add_settings_field(
+            'ns_vr_default_type',
+            __( 'نوع نمایش پیشفرض ویژگی', 'nias-variation-swatches' ),
+            array( $this, 'render_default_type_field' ),
+            'nias-variation-swatches-settings',
+            'ns_vr_general_section'
+        );
+
+        // Style Section
+        add_settings_section(
+            'ns_vr_style_section',
+            __( 'تنظیمات استایل', 'nias-variation-swatches' ),
+            null,
+            'nias-variation-swatches-settings'
+        );
+
+        add_settings_field(
+            'ns_vr_swatch_style',
+            __( 'استایل نمونه رنگ', 'nias-variation-swatches' ),
+            array( $this, 'render_swatch_style_field' ),
+            'nias-variation-swatches-settings',
+            'ns_vr_style_section'
+        );
+    }
+
+    public function render_default_type_field() {
+        $options = get_option( 'ns_vr_settings' );
+        $value = isset( $options['default_type'] ) ? $options['default_type'] : 'button';
+        ?>
+        <label>
+            <input type="radio" name="ns_vr_settings[default_type]" value="color" <?php checked( $value, 'color' ); ?>>
+            <?php _e( 'نمونه رنگ', 'nias-variation-swatches' ); ?>
+        </label>
+        <br>
+        <label>
+            <input type="radio" name="ns_vr_settings[default_type]" value="button" <?php checked( $value, 'button' ); ?>>
+            <?php _e( 'دکمه', 'nias-variation-swatches' ); ?>
+        </label>
+        <?php
+    }
+
+    public function render_swatch_style_field() {
+        $options = get_option( 'ns_vr_settings' );
+        $width = isset( $options['swatch_width'] ) ? $options['swatch_width'] : '32';
+        $height = isset( $options['swatch_height'] ) ? $options['swatch_height'] : '32';
+        $shape = isset( $options['swatch_shape'] ) ? $options['swatch_shape'] : 'circle';
+        ?>
+        <p>
+            <label for="ns_vr_settings[swatch_width]"><?php _e( 'عرض:', 'nias-variation-swatches' ); ?></label>
+            <input type="number" name="ns_vr_settings[swatch_width]" id="ns_vr_settings[swatch_width]" value="<?php echo esc_attr( $width ); ?>" class="small-text"> px
+        </p>
+        <p>
+            <label for="ns_vr_settings[swatch_height]"><?php _e( 'ارتفاع:', 'nias-variation-swatches' ); ?></label>
+            <input type="number" name="ns_vr_settings[swatch_height]" id="ns_vr_settings[swatch_height]" value="<?php echo esc_attr( $height ); ?>" class="small-text"> px
+        </p>
+        <p>
+            <label><?php _e( 'شکل:', 'nias-variation-swatches' ); ?></label>
+            <br>
+            <label>
+                <input type="radio" name="ns_vr_settings[swatch_shape]" value="circle" <?php checked( $shape, 'circle' ); ?>>
+                <?php _e( 'دایره', 'nias-variation-swatches' ); ?>
+            </label>
+            <br>
+            <label>
+                <input type="radio" name="ns_vr_settings[swatch_shape]" value="square" <?php checked( $shape, 'square' ); ?>>
+                <?php _e( 'مربع', 'nias-variation-swatches' ); ?>
+            </label>
+        </p>
+        <?php
+    }
+
+    public function sanitize_settings( $input ) {
+        $new_input = array();
+
+        if ( isset( $input['default_type'] ) ) {
+            $new_input['default_type'] = sanitize_text_field( $input['default_type'] );
+        }
+        if ( isset( $input['swatch_width'] ) ) {
+            $new_input['swatch_width'] = absint( $input['swatch_width'] );
+        }
+        if ( isset( $input['swatch_height'] ) ) {
+            $new_input['swatch_height'] = absint( $input['swatch_height'] );
+        }
+        if ( isset( $input['swatch_shape'] ) ) {
+            $new_input['swatch_shape'] = sanitize_text_field( $input['swatch_shape'] );
+        }
+
+        return $new_input;
+    }
+}

--- a/nias-variation-swatches/includes/class-frontend-display.php
+++ b/nias-variation-swatches/includes/class-frontend-display.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Swatches and Buttons Display in Product Page
+ *
+ * @package Nias_Variation_Swatches
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class NS_VR_Frontend_Display {
+
+    public function __construct() {
+        add_filter( 'woocommerce_dropdown_variation_attribute_options_html', array( $this, 'get_swatches_html' ), 100, 2 );
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+    }
+
+    public function enqueue_scripts() {
+        if ( is_product() ) {
+            global $product;
+            if ( $product && $product->is_type( 'variable' ) ) {
+                wp_enqueue_style( 'ns-vr-frontend-style', NS_VR_PLUGIN_URL . 'assets/css/frontend.css', array(), NS_VR_VERSION );
+                wp_enqueue_script( 'ns-vr-frontend-script', NS_VR_PLUGIN_URL . 'assets/js/frontend.js', array( 'jquery' ), NS_VR_VERSION, true );
+
+                $settings = get_option('ns_vr_settings');
+                wp_localize_script('ns-vr-frontend-script', 'ns_vr_settings', $settings);
+
+                $this->add_dynamic_styles();
+            }
+        }
+    }
+
+    public function add_dynamic_styles() {
+        $options = get_option( 'ns_vr_settings' );
+        $width = isset( $options['swatch_width'] ) ? $options['swatch_width'] : '32';
+        $height = isset( $options['swatch_height'] ) ? $options['swatch_height'] : '32';
+        $shape = isset( $options['swatch_shape'] ) ? $options['swatch_shape'] : 'circle';
+        $border_radius = ( $shape === 'circle' ) ? '50%' : '0';
+
+        $style = "
+            .ns-vr-swatch .ns-vr-swatch-color, .ns-vr-swatch .ns-vr-swatch-label {
+                width: {$width}px;
+                height: {$height}px;
+                border-radius: {$border_radius};
+            }
+            .ns-vr-swatch .ns-vr-swatch-label {
+                line-height: {$height}px;
+            }
+        ";
+        wp_add_inline_style( 'ns-vr-frontend-style', $style );
+    }
+
+    public function get_swatches_html( $html, $args ) {
+        $product = $args['product'];
+        $attribute = $args['attribute'];
+
+        // This function is deprecated since WC 2.4, but we keep it for compatibility.
+        // For newer versions, we get terms from $args['options'].
+        $terms = $args['options'];
+        if (empty($terms) && $product && $product->is_type('variable')) {
+            $attributes = $product->get_variation_attributes();
+            $terms = $attributes[$attribute];
+        }
+
+        $attribute_tax = get_taxonomy( $attribute );
+
+        ob_start();
+
+        wc_get_template(
+            'variation-swatches.php',
+            array(
+                'terms'     => $terms,
+                'taxonomy'  => $attribute_tax,
+                'attribute' => $attribute,
+                'product'   => $product,
+                'args'      => $args,
+            ),
+            '',
+            NS_VR_PLUGIN_PATH . 'templates/'
+        );
+
+        echo '<div class="original-variation-select" style="display:none;">' . $html . '</div>';
+
+        return ob_get_clean();
+    }
+}

--- a/nias-variation-swatches/includes/class-plugin-links.php
+++ b/nias-variation-swatches/includes/class-plugin-links.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Adds Settings Link in Plugin List
+ *
+ * @package Nias_Variation_Swatches
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class NS_VR_Plugin_Links {
+    public function __construct() {
+        $plugin_basename = plugin_basename( NS_VR_PLUGIN_PATH . 'nias-variation-swatches.php' );
+        add_filter( 'plugin_action_links_' . $plugin_basename, array( $this, 'add_settings_link' ) );
+    }
+
+    /**
+     * Add a settings link to the plugin's entry on the plugins page.
+     *
+     * @param array $links An array of plugin action links.
+     * @return array An array of plugin action links.
+     */
+    public function add_settings_link( $links ) {
+        $settings_link = '<a href="' . admin_url( 'admin.php?page=nias-variation-swatches-settings' ) . '">' . __( 'Settings', 'nias-variation-swatches' ) . '</a>';
+        // The user wants the default text to be in Persian. Let's change the text.
+        // I will use "تنظیمات" which means "Settings" in Persian.
+        $settings_link = '<a href="' . admin_url( 'admin.php?page=nias-variation-swatches-settings' ) . '">' . 'تنظیمات' . '</a>';
+        array_unshift( $links, $settings_link );
+        return $links;
+    }
+}

--- a/nias-variation-swatches/includes/class-variation-taxonomy.php
+++ b/nias-variation-swatches/includes/class-variation-taxonomy.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Attribute Management and Display
+ *
+ * @package Nias_Variation_Swatches
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class NS_VR_Variation_Taxonomy {
+    public function __construct() {
+        $attribute_taxonomies = wc_get_attribute_taxonomies();
+        if ( ! empty( $attribute_taxonomies ) ) {
+            foreach ( $attribute_taxonomies as $tax ) {
+                $taxonomy_name = wc_attribute_taxonomy_name( $tax->attribute_name );
+                // Only add color picker for attributes that are of type 'select'
+                if ( $tax->attribute_type === 'select' ) {
+                    add_action( "{$taxonomy_name}_add_form_fields", array( $this, 'add_color_picker_field' ) );
+                    add_action( "{$taxonomy_name}_edit_form_fields", array( $this, 'edit_color_picker_field' ), 10, 2 );
+
+                    add_action( "created_{$taxonomy_name}", array( $this, 'save_color_picker_field' ), 10, 2 );
+                    add_action( "edited_{$taxonomy_name}", array( $this, 'save_color_picker_field' ), 10, 2 );
+                }
+            }
+        }
+
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+    }
+
+    public function enqueue_scripts( $hook ) {
+        $screen = get_current_screen();
+        if ( $screen && (strpos($screen->id, 'pa_') !== false) && ($hook === 'term.php' || $hook === 'edit-tags.php') ) {
+            wp_enqueue_style( 'wp-color-picker' );
+            wp_enqueue_script( 'wp-color-picker' );
+            add_action('admin_footer', array($this, 'add_color_picker_js'));
+        }
+    }
+
+    public function add_color_picker_js() {
+        ?>
+        <script type="text/javascript">
+            jQuery(document).ready(function($){
+                $('.ns-vr-color-picker').wpColorPicker();
+            });
+        </script>
+        <?php
+    }
+
+    public function add_color_picker_field() {
+        ?>
+        <div class="form-field">
+            <label for="ns-vr-color"><?php _e( 'رنگ', 'nias-variation-swatches' ); ?></label>
+            <input type="text" name="ns_vr_color" id="ns-vr-color" class="ns-vr-color-picker" value="#ffffff">
+            <p class="description"><?php _e( 'یک رنگ برای این مقدار ویژگی انتخاب کنید.', 'nias-variation-swatches' ); ?></p>
+        </div>
+        <?php
+    }
+
+    public function edit_color_picker_field( $term, $taxonomy ) {
+        $color = get_term_meta( $term->term_id, 'ns_vr_color', true );
+        $color = ! empty( $color ) ? esc_attr( $color ) : '#ffffff';
+        ?>
+        <tr class="form-field">
+            <th scope="row" valign="top"><label for="ns-vr-color"><?php _e( 'رنگ', 'nias-variation-swatches' ); ?></label></th>
+            <td>
+                <input type="text" name="ns_vr_color" id="ns-vr-color" class="ns-vr-color-picker" value="<?php echo $color; ?>">
+                <p class="description"><?php _e( 'یک رنگ برای این مقدار ویژگی انتخاب کنید.', 'nias-variation-swatches' ); ?></p>
+            </td>
+        </tr>
+        <?php
+    }
+
+    public function save_color_picker_field( $term_id ) {
+        if ( isset( $_POST['ns_vr_color'] ) && ! empty( $_POST['ns_vr_color'] ) ) {
+            $color = sanitize_hex_color( $_POST['ns_vr_color'] );
+            update_term_meta( $term_id, 'ns_vr_color', $color );
+        } else {
+            delete_term_meta( $term_id, 'ns_vr_color' );
+        }
+    }
+}

--- a/nias-variation-swatches/nias-variation-swatches.php
+++ b/nias-variation-swatches/nias-variation-swatches.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Plugin Name:       متغیر پیشرفته نیاس | nias variation swatches
+ * Plugin URI:        https://nias.ir/
+ * Description:       افزونه انتخاب ویژگی حرفه ای محصولات برای ووکامرس
+ * Version:           1.0.0
+ * Author:            نیاس
+ * Author URI:        https://nias.ir/
+ * License:           GPL v2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       nias-variation-swatches
+ * Domain Path:       /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+final class Nias_Variation_Swatches {
+
+    const VERSION = '1.0.0';
+    const PREFIX = 'ns_vr';
+    const TEXT_DOMAIN = 'nias-variation-swatches';
+
+    private static $_instance = null;
+
+    public static function instance() {
+        if ( is_null( self::$_instance ) ) {
+            self::$_instance = new self();
+        }
+        return self::$_instance;
+    }
+
+    private function __construct() {
+        $this->define_constants();
+        $this->includes();
+        $this->init();
+    }
+
+    private function define_constants() {
+        define( 'NS_VR_VERSION', self::VERSION );
+        define( 'NS_VR_PREFIX', self::PREFIX );
+        define( 'NS_VR_TEXT_DOMAIN', self::TEXT_DOMAIN );
+        define( 'NS_VR_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+        define( 'NS_VR_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+    }
+
+    public function includes() {
+        require_once NS_VR_PLUGIN_PATH . 'includes/class-admin-menu.php';
+        require_once NS_VR_PLUGIN_PATH . 'includes/class-plugin-links.php';
+        require_once NS_VR_PLUGIN_PATH . 'includes/class-variation-taxonomy.php';
+        require_once NS_VR_PLUGIN_PATH . 'includes/class-frontend-display.php';
+    }
+
+    public function init() {
+        // It is better to instantiate classes inside a hook like `plugins_loaded`
+        // to ensure all plugins are loaded and functions are available.
+        add_action('plugins_loaded', array($this, 'initialize_classes'));
+    }
+
+    public function initialize_classes() {
+        if (class_exists('WooCommerce')) {
+            new NS_VR_Admin_Menu();
+            new NS_VR_Plugin_Links();
+            new NS_VR_Variation_Taxonomy();
+            new NS_VR_Frontend_Display();
+        } else {
+            add_action('admin_notices', array($this, 'woocommerce_not_active_notice'));
+        }
+    }
+
+    public function woocommerce_not_active_notice() {
+        ?>
+        <div class="notice notice-error is-dismissible">
+            <p><?php _e( 'Nias Variation Swatches requires WooCommerce to be active. Please activate WooCommerce.', 'nias-variation-swatches' ); ?></p>
+        </div>
+        <?php
+    }
+}
+
+function NVS() {
+    return Nias_Variation_Swatches::instance();
+}
+
+// Initialize the plugin
+NVS();

--- a/nias-variation-swatches/readme.txt
+++ b/nias-variation-swatches/readme.txt
@@ -1,0 +1,39 @@
+=== Nias Variation Swatches ===
+Contributors: nias
+Donate link: https://nias.ir/
+Tags: woocommerce, product, variation, swatches, color, button
+Requires at least: 5.0
+Tested up to: 6.0
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Nias Variation Swatches is a WooCommerce extension that allows you to display product variations as color swatches, images, or buttons.
+
+== Description ==
+
+This plugin provides a more user-friendly way to display product variations. Instead of dropdowns, you can use color swatches, images, or buttons to represent your product attributes like color, size, and style.
+
+== Installation ==
+
+1. Upload the plugin files to the `/wp-content/plugins/nias-variation-swatches` directory, or install the plugin through the WordPress plugins screen directly.
+2. Activate the plugin through the 'Plugins' screen in WordPress
+3. Use the "متغیر پیشرفته نیاس" menu to configure the plugin.
+
+== Frequently Asked Questions ==
+
+* A list of frequently asked questions will be added here.
+
+== Screenshots ==
+
+* Screenshots will be added here.
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release.
+
+== Upgrade Notice ==
+
+= 1.0.0 =
+* Initial release.

--- a/nias-variation-swatches/templates/variation-swatches.php
+++ b/nias-variation-swatches/templates/variation-swatches.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Template for displaying attributes in product page
+ *
+ * @package Nias_Variation_Swatches
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+$attribute_name = $args['attribute'];
+$options = $args['options'];
+$product = $args['product'];
+$selected_value = isset( $_REQUEST[ 'attribute_' . sanitize_title( $attribute_name ) ] ) ? wc_clean( wp_unslash( $_REQUEST[ 'attribute_' . sanitize_title( $attribute_name ) ] ) ) : $product->get_variation_default_attribute( $attribute_name );
+
+?>
+<div class="ns-vr-swatches-container" data-attribute-name="attribute_<?php echo esc_attr( sanitize_title( $attribute_name ) ); ?>">
+    <?php
+    if ( ! empty( $options ) ) {
+        if ( $product && taxonomy_exists( $attribute_name ) ) {
+            // Get terms if this is a taxonomy - ordered. We need the names and slugs.
+            $terms = wc_get_product_terms( $product->get_id(), $attribute_name, array( 'fields' => 'all' ) );
+
+            foreach ( $terms as $term ) {
+                if ( ! in_array( $term->slug, $options, true ) ) {
+                    continue;
+                }
+
+                $is_selected = ( $selected_value === $term->slug );
+                $color = get_term_meta( $term->term_id, 'ns_vr_color', true );
+                $color = ! empty( $color ) ? sanitize_hex_color( $color ) : '';
+
+                $swatch_class = 'ns-vr-swatch';
+                if ( $is_selected ) {
+                    $swatch_class .= ' selected';
+                }
+                ?>
+                <div class="<?php echo esc_attr( $swatch_class ); ?>" data-value="<?php echo esc_attr( $term->slug ); ?>" title="<?php echo esc_attr( $term->name ); ?>">
+                    <?php if ( ! empty( $color ) ) : ?>
+                        <span class="ns-vr-swatch-color" style="background-color: <?php echo esc_attr( $color ); ?>;"></span>
+                    <?php else : ?>
+                        <span class="ns-vr-swatch-label"><?php echo esc_html( $term->name ); ?></span>
+                    <?php endif; ?>
+                </div>
+                <?php
+            }
+        }
+    }
+    ?>
+</div>


### PR DESCRIPTION
This commit introduces the initial version of the Nias Variation Swatches plugin for WooCommerce.

The plugin provides the following features:
- A custom admin menu and settings page to configure the plugin's behavior and appearance.
- A "Settings" link on the plugins page for quick access.
- A color picker on the attribute term management pages to assign colors to attribute values.
- Frontend replacement of default variation dropdowns with color swatches or buttons.
- Customizable swatch styles (width, height, shape) from the settings page.
- All frontend and backend text is in Persian, as per the project requirements.

The plugin is structured with a clear separation of concerns, using different classes for admin functionality, frontend display, and taxonomy management. It follows WordPress and WooCommerce best practices.