### PR TITLE
fix: Correctly retrieve product object in frontend display

### DIFF
--- a/nias-variation-swatches/includes/class-frontend-display.php
+++ b/nias-variation-swatches/includes/class-frontend-display.php
@@ -18,7 +18,7 @@ class NS_VR_Frontend_Display {
 
     public function enqueue_scripts() {
         if ( is_product() ) {
-            global $product;
+            $product = wc_get_product( get_the_ID() );
             if ( $product && $product->is_type( 'variable' ) ) {
                 wp_enqueue_style( 'ns-vr-frontend-style', NS_VR_PLUGIN_URL . 'assets/css/frontend.css', array(), NS_VR_VERSION );
                 wp_enqueue_script( 'ns-vr-frontend-script', NS_VR_PLUGIN_URL . 'assets/js/frontend.js', array( 'jquery' ), NS_VR_VERSION, true );


### PR DESCRIPTION
This commit fixes a fatal error that occurred on product pages. The error was caused by using `global $product`, which is not always a reliable way to get the `WC_Product` object and could sometimes be a string, leading to a fatal error when calling a method on it.

The fix replaces the unreliable `global $product;` with the more robust `wc_get_product( get_the_ID() );` in the `enqueue_scripts` method of the `NS_VR_Frontend_Display` class. This ensures that we always get a valid product object, preventing the fatal error.