### PR TITLE
feat: Add attribute-level display type setting

### DIFF
--- a/nias-variation-swatches/includes/class-variation-taxonomy.php
+++ b/nias-variation-swatches/includes/class-variation-taxonomy.php
@@ -11,11 +11,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class NS_VR_Variation_Taxonomy {
     public function __construct() {
+        // Hooks for attribute terms (color picker)
         $attribute_taxonomies = wc_get_attribute_taxonomies();
         if ( ! empty( $attribute_taxonomies ) ) {
             foreach ( $attribute_taxonomies as $tax ) {
                 $taxonomy_name = wc_attribute_taxonomy_name( $tax->attribute_name );
-                // Only add color picker for attributes that are of type 'select'
                 if ( $tax->attribute_type === 'select' ) {
                     add_action( "{$taxonomy_name}_add_form_fields", array( $this, 'add_color_picker_field' ) );
                     add_action( "{$taxonomy_name}_edit_form_fields", array( $this, 'edit_color_picker_field' ), 10, 2 );
@@ -26,6 +26,15 @@ class NS_VR_Variation_Taxonomy {
             }
         }
 
+        // Hooks for attribute settings (display type)
+        add_action( 'woocommerce_after_add_attribute_fields', array( $this, 'add_attribute_display_type_field' ) );
+        add_action( 'woocommerce_after_edit_attribute_fields', array( $this, 'edit_attribute_display_type_field' ) );
+
+        // Hooks for saving attribute display type
+        add_action( 'woocommerce_attribute_added', array( $this, 'save_attribute_display_type' ), 10, 2 );
+        add_action( 'woocommerce_attribute_updated', array( $this, 'save_attribute_display_type' ), 10, 2 );
+
+        // Enqueue scripts
         add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
     }
 
@@ -78,6 +87,59 @@ class NS_VR_Variation_Taxonomy {
             update_term_meta( $term_id, 'ns_vr_color', $color );
         } else {
             delete_term_meta( $term_id, 'ns_vr_color' );
+        }
+    }
+
+    /**
+     * Add display type field to the "Add Attribute" form.
+     */
+    public function add_attribute_display_type_field() {
+        ?>
+        <div class="form-field">
+            <label for="ns_vr_attribute_display_type"><?php _e( 'نوع نمایش', 'nias-variation-swatches' ); ?></label>
+            <select name="ns_vr_attribute_display_type" id="ns_vr_attribute_display_type">
+                <option value="default"><?php _e( 'پیشفرض', 'nias-variation-swatches' ); ?></option>
+                <option value="color"><?php _e( 'نمونه رنگ', 'nias-variation-swatches' ); ?></option>
+                <option value="button"><?php _e( 'دکمه', 'nias-variation-swatches' ); ?></option>
+            </select>
+            <p class="description"><?php _e( 'نحوه نمایش این ویژگی در صفحه محصول را انتخاب کنید.', 'nias-variation-swatches' ); ?></p>
+        </div>
+        <?php
+    }
+
+    /**
+     * Add display type field to the "Edit Attribute" form.
+     */
+    public function edit_attribute_display_type_field() {
+        $attribute_id = $_GET['edit'];
+        $display_type = get_option( 'ns_vr_attribute_display_type_' . $attribute_id );
+        ?>
+        <tr class="form-field">
+            <th scope="row" valign="top">
+                <label for="ns_vr_attribute_display_type"><?php _e( 'نوع نمایش', 'nias-variation-swatches' ); ?></label>
+            </th>
+            <td>
+                <select name="ns_vr_attribute_display_type" id="ns_vr_attribute_display_type">
+                    <option value="default" <?php selected( $display_type, 'default' ); ?>><?php _e( 'پیشفرض', 'nias-variation-swatches' ); ?></option>
+                    <option value="color" <?php selected( $display_type, 'color' ); ?>><?php _e( 'نمونه رنگ', 'nias-variation-swatches' ); ?></option>
+                    <option value="button" <?php selected( $display_type, 'button' ); ?>><?php _e( 'دکمه', 'nias-variation-swatches' ); ?></option>
+                </select>
+                <p class="description"><?php _e( 'نحوه نمایش این ویژگی در صفحه محصول را انتخاب کنید.', 'nias-variation-swatches' ); ?></p>
+            </td>
+        </tr>
+        <?php
+    }
+
+    /**
+     * Save the attribute display type.
+     *
+     * @param int   $attribute_id   Attribute ID.
+     * @param array $attribute      Attribute data.
+     */
+    public function save_attribute_display_type( $attribute_id, $attribute ) {
+        if ( isset( $_POST['ns_vr_attribute_display_type'] ) ) {
+            $display_type = sanitize_text_field( $_POST['ns_vr_attribute_display_type'] );
+            update_option( 'ns_vr_attribute_display_type_' . $attribute_id, $display_type );
         }
     }
 }

--- a/nias-variation-swatches/templates/variation-swatches.php
+++ b/nias-variation-swatches/templates/variation-swatches.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $attribute_name = $args['attribute'];
 $options = $args['options'];
 $product = $args['product'];
+// $display_type is passed from the calling function in class-frontend-display.php
 $selected_value = isset( $_REQUEST[ 'attribute_' . sanitize_title( $attribute_name ) ] ) ? wc_clean( wp_unslash( $_REQUEST[ 'attribute_' . sanitize_title( $attribute_name ) ] ) ) : $product->get_variation_default_attribute( $attribute_name );
 
 ?>
@@ -19,7 +20,6 @@ $selected_value = isset( $_REQUEST[ 'attribute_' . sanitize_title( $attribute_na
     <?php
     if ( ! empty( $options ) ) {
         if ( $product && taxonomy_exists( $attribute_name ) ) {
-            // Get terms if this is a taxonomy - ordered. We need the names and slugs.
             $terms = wc_get_product_terms( $product->get_id(), $attribute_name, array( 'fields' => 'all' ) );
 
             foreach ( $terms as $term ) {
@@ -28,20 +28,27 @@ $selected_value = isset( $_REQUEST[ 'attribute_' . sanitize_title( $attribute_na
                 }
 
                 $is_selected = ( $selected_value === $term->slug );
-                $color = get_term_meta( $term->term_id, 'ns_vr_color', true );
-                $color = ! empty( $color ) ? sanitize_hex_color( $color ) : '';
-
                 $swatch_class = 'ns-vr-swatch';
                 if ( $is_selected ) {
                     $swatch_class .= ' selected';
                 }
+
+                $swatch_class .= ' ns-vr-swatch-' . esc_attr($display_type);
+
                 ?>
                 <div class="<?php echo esc_attr( $swatch_class ); ?>" data-value="<?php echo esc_attr( $term->slug ); ?>" title="<?php echo esc_attr( $term->name ); ?>">
-                    <?php if ( ! empty( $color ) ) : ?>
-                        <span class="ns-vr-swatch-color" style="background-color: <?php echo esc_attr( $color ); ?>;"></span>
-                    <?php else : ?>
-                        <span class="ns-vr-swatch-label"><?php echo esc_html( $term->name ); ?></span>
-                    <?php endif; ?>
+                    <?php
+                    $color = get_term_meta( $term->term_id, 'ns_vr_color', true );
+                    $color = ! empty( $color ) ? sanitize_hex_color( $color ) : '';
+
+                    if ( $display_type === 'color' && ! empty( $color ) ) {
+                        // Color type swatch
+                        echo '<span class="ns-vr-swatch-color" style="background-color: ' . esc_attr( $color ) . ';"></span>';
+                    } else {
+                        // Button type swatch
+                        echo '<span class="ns-vr-swatch-label">' . esc_html( $term->name ) . '</span>';
+                    }
+                    ?>
                 </div>
                 <?php
             }


### PR DESCRIPTION
This commit introduces a new feature that allows setting the display type (swatch or button) on a per-attribute basis, overriding the global setting.

Key changes:
- Adds a "Display Type" dropdown to the WooCommerce attribute "Add" and "Edit" pages. This allows administrators to choose between "Default", "Color Swatch", or "Button" for each attribute.
- The selected display type is saved as a WordPress option, specific to each attribute.
- The frontend display logic has been updated to check for this attribute-specific setting first. If it's not set or is 'Default', it falls back to the global setting from the plugin's main options.
- The frontend template (`variation-swatches.php`) is updated to conditionally render a color swatch or a button-style label based on the determined display type. This includes a fallback to a button style if an attribute is set to "Color Swatch" but a specific term has no color value assigned.